### PR TITLE
Added support for plaintext credentials in pwsh scripts

### DIFF
--- a/Private/Find-LogonScriptCredentials.ps1
+++ b/Private/Find-LogonScriptCredentials.ps1
@@ -6,7 +6,7 @@ function Find-LogonScriptCredentials {
     )
     foreach ($script in $LogonScripts) {
         # Write-Verbose -Message "Checking $($Script.FullName) for credentials.."
-        $Credentials = Get-Content -Path $script.FullName | Select-String -Pattern "/user:" -AllMatches
+        $Credentials = Get-Content -Path $script.FullName | Select-String -Pattern "/user:","-AsPlainText" -AllMatches
         if ($Credentials) {
             # "`n[!] CREDENTIALS FOUND!"
             $Credentials | ForEach-Object {


### PR DESCRIPTION
Added support for plaintext credentials in pwsh scripts.

Awesome tool, keep up the great work!

```
########## Plaintext credentials ##########

Type        File                                                                                        Credential
----        ----                                                                                        ----------
Credentials \\pharmax.local\sysvol\pharmax.local\scripts\AD-Find_missing_subnets_in_ActiveDirectory.ps1 $password = ConvertTo-SecureString -String "p@ssw0rd" -AsPlainText -Force
Credentials \\pharmax.local\sysvol\pharmax.local\scripts\mappeddrives.cmd                               Net use h: \\VBoxSvr\Win11\Documents /user:VboxSrv\user1 Passwrd123 /p:yes
```