### PR TITLE
Version 0.2 PR

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -102,8 +102,8 @@ Build-Module -ModuleName 'ScriptSentry' {
     # New-ConfigurationArtefact -Type Unpacked -Enable -Path "$PSScriptRoot\..\Artefacts\Unpacked"
     # New-ConfigurationArtefact -Type Packed -Enable -Path "$PSScriptRoot\..\Artefacts\Packed" -IncludeTagName
 
-    # New-ConfigurationArtefact -Type Script -Enable -Path "$PSScriptRoot\..\Script" {
-    #     Invoke-ModuleBuilder
+    # New-ConfigurationArtefact -Type Script -Enable -Path "$PSScriptRoot\..\" {
+    #      Invoke-ModuleBuilder
     # }
 
     # global options for publishing to github/psgallery

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -16,7 +16,7 @@ Import-Module -Name PSPublishModule -Force
 Build-Module -ModuleName 'ScriptSentry' {
     # Usual defaults as per standard module
     $Manifest = [ordered] @{
-        ModuleVersion        = '0.1'
+        ModuleVersion        = '0.2'
         CompatiblePSEditions = @('Desktop', 'Core')
         GUID                 = 'e1cd2b55-3b4f-41bd-a168-40db41e34349'
         Author               = 'Spencer Alessi'

--- a/Private/Find-AdminLogonScripts.ps1
+++ b/Private/Find-AdminLogonScripts.ps1
@@ -1,4 +1,6 @@
 function Find-AdminLogonScripts {
+    Write-Verbose -Message "Checking for admins who have logon scripts set.."
+
     $AdminGroups = "Domain Admins|Enterprise Admins|Administrators"
     # $AdminLogonScripts = Get-ADUser -Filter {Enabled -eq $true} -Properties samaccountname,scriptPath,memberOf | Where-Object {$null -ne $_.scriptPath -and $_.MemberOf -match $AdminGroups}
     
@@ -21,10 +23,13 @@ function Find-AdminLogonScripts {
     # Filter the results based on scriptPath and memberOf properties
     $AdminLogonScripts = $results | Where-Object { $_.Properties["scriptPath"] -ne $null -and ($adminGroups -match $AdminGroups) }
 
-     "`n[!] Admins found with logon scripts"
+    # "`n[!] Admins found with logon scripts"
     $AdminLogonScripts | Foreach-object {
-        "- User: $($_.Path)"
-        "- logonscript: $($_.Properties.scriptpath)"
-        ""    
-    }   
+        $Results = [ordered] @{
+            Type = 'AdminLogonScript'
+            User = $_.Path
+            LogonScript = $($_.Properties.scriptpath)
+        }
+        [pscustomobject] $Results
+    }
 }

--- a/Private/Find-AdminLogonScripts.ps1
+++ b/Private/Find-AdminLogonScripts.ps1
@@ -1,14 +1,11 @@
 function Find-AdminLogonScripts {
-    Write-Verbose -Message "Checking for admins who have logon scripts set.."
-
-    $AdminGroups = "Domain Admins|Enterprise Admins|Administrators"
-    # $AdminLogonScripts = Get-ADUser -Filter {Enabled -eq $true} -Properties samaccountname,scriptPath,memberOf | Where-Object {$null -ne $_.scriptPath -and $_.MemberOf -match $AdminGroups}
+    # Write-Verbose -Message "Checking for admins who have logon scripts set.."
     
     # Enabled user accounts
     $ldapFilter = "(&(objectCategory=User)(objectClass=person)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))"
 
     # Admin groups to match on
-    $AdminGroups = "Domain Admins|Enterprise Admins|Administrators"
+    $AdminGroups = "Account Operators|Administrators|Backup Operators|Cryptographic Operators|Distributed COM Users|Domain Admins|Domain Controllers|Enterprise Admins|Print Operators|Schema Admins|Server Operators"
 
     # Create a new ADSI searcher object
     $searcher = [adsisearcher]$ldapFilter

--- a/Private/Find-LogonScriptCredentials.ps1
+++ b/Private/Find-LogonScriptCredentials.ps1
@@ -5,7 +5,7 @@ function Find-LogonScriptCredentials {
         [array]$LogonScripts
     )
     foreach ($script in $LogonScripts) {
-        Write-Verbose -Message "Checking $($Script.FullName) for credentials.."
+        # Write-Verbose -Message "Checking $($Script.FullName) for credentials.."
         $Credentials = Get-Content -Path $script.FullName | Select-String -Pattern "/user:" -AllMatches
         if ($Credentials) {
             # "`n[!] CREDENTIALS FOUND!"

--- a/Private/Find-LogonScriptCredentials.ps1
+++ b/Private/Find-LogonScriptCredentials.ps1
@@ -8,12 +8,15 @@ function Find-LogonScriptCredentials {
         Write-Verbose -Message "Checking $($Script.FullName) for credentials.."
         $Credentials = Get-Content -Path $script.FullName | Select-String -Pattern "/user:" -AllMatches
         if ($Credentials) {
-            "`n[!] CREDENTIALS FOUND!"
-            "- File: $($script.FullName)"
+            # "`n[!] CREDENTIALS FOUND!"
             $Credentials | ForEach-Object {
-                "`t- Credential: $_"
+                $Results = [ordered] @{
+                    Type = 'Credentials'
+                    File = $script.FullName
+                    Credential = $_
+                }
+                [pscustomobject] $Results
             }
-             ""
         }
-    } 
+    }
 }

--- a/Private/Find-MappedDrives.ps1
+++ b/Private/Find-MappedDrives.ps1
@@ -17,5 +17,11 @@ function Find-MappedDrives {
             }
         }
     }
+
+    Write-Verbose "[+] Mapped drives:"
+    $Shares | Sort-Object -Unique | ForEach-Object {
+        Write-Verbose -Message "$_"
+    }
+
     $Shares | Sort-Object -Unique
 }

--- a/Private/Find-MappedDrives.ps1
+++ b/Private/Find-MappedDrives.ps1
@@ -1,0 +1,21 @@
+function Find-MappedDrives {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [array]$LogonScripts
+    )
+
+    $Shares = @()
+    [Array] $Shares = foreach ($script in $LogonScripts) {
+        # Kind of messy, but it works? Could not get the regex 100% perfect
+        $temp = Get-Content $script.FullName | Select-String -Pattern '\\\\[\w\.\-]+\\[\w\-_\\.]+' | ForEach-Object { $_.Matches.Value } 
+        $temp | ForEach-Object {
+            if ($_ -match '\.') {
+                (Get-Item $_).Directory.FullName
+            } else {
+                $_
+            }
+        }
+    }
+    $Shares | Sort-Object -Unique
+}

--- a/Private/Find-UnsafeLogonScriptPermissions.ps1
+++ b/Private/Find-UnsafeLogonScriptPermissions.ps1
@@ -16,11 +16,13 @@ function Find-UnsafeLogonScriptPermissions {
                 -and $entry.AccessControlType -eq "Allow" `
                 -and $entry.IdentityReference -notmatch $SafeUsers
                 ){
-                    "`n[!] UNSAFE ACL FOUND!"
-                    "- File: $($script.FullName)"
-                    "- User: $($entry.IdentityReference.Value)"
-                    "- Rights: $($entry.FileSystemRights)"
-                    ""
+                $Results = [ordered] @{
+                    Type = 'UnsafeLogonScriptPermission'
+                    File = $script.FullName
+                    User = $entry.IdentityReference.Value
+                    Rights = $entry.FileSystemRights
+                }
+                [pscustomobject] $Results
             }
         }
     }

--- a/Private/Find-UnsafeLogonScriptPermissions.ps1
+++ b/Private/Find-UnsafeLogonScriptPermissions.ps1
@@ -9,7 +9,7 @@ function Find-UnsafeLogonScriptPermissions {
     $SafeUsers = 'NT AUTHORITY\\SYSTEM|Administrator'
     $DomainAdmins | ForEach-Object { $SafeUsers = $SafeUsers + '|' + $_ }
     foreach ($script in $LogonScripts){
-        Write-Verbose -Message "Checking $($script.FullName) for unsafe permissions.."
+        # Write-Verbose -Message "Checking $($script.FullName) for unsafe permissions.."
         $ACL = (Get-Acl $script.FullName).Access
         foreach ($entry in $ACL) {
             if ($entry.FileSystemRights -match $UnsafeRights `

--- a/Private/Find-UnsafeUNCPermissions.ps1
+++ b/Private/Find-UnsafeUNCPermissions.ps1
@@ -17,11 +17,18 @@ function Find-UnsafeUNCPermissions {
                 -and $entry.AccessControlType -eq "Allow" `
                 -and $entry.IdentityReference -notmatch $SafeUsers
                 ){
-                    "`n[!] UNSAFE ACL FOUND!"
-                    "- File: $script"
-                    "- User: $($entry.IdentityReference.Value)"
-                    "- Rights: $($entry.FileSystemRights)"
-                    ""
+                if ($script -match '\.') {
+                    $Type = 'UnsafeUNCFilePermission'
+                } else {
+                    $Type = 'UnsafeUNCFolderPermission'
+                }
+                $Results = [ordered] @{
+                    Type = $Type
+                    File = $script
+                    User = $entry.IdentityReference.Value
+                    Rights = $entry.FileSystemRights
+                }
+                [pscustomobject] $Results
             }
         }
     }

--- a/Private/Find-UnsafeUNCPermissions.ps1
+++ b/Private/Find-UnsafeUNCPermissions.ps1
@@ -10,7 +10,7 @@ function Find-UnsafeUNCPermissions {
     $SafeUsers = 'NT AUTHORITY\\SYSTEM|Administrator'
     $DomainAdmins | ForEach-Object { $SafeUsers = $SafeUsers + '|' + $_ }
     foreach ($script in $UNCScripts){
-        Write-Verbose -Message "Checking $script for unsafe permissions.."
+        # Write-Verbose -Message "Checking $script for unsafe permissions.."
         $ACL = (Get-Acl $script).Access
         foreach ($entry in $ACL) {
             if ($entry.FileSystemRights -match $UnsafeRights `

--- a/Private/Show-Results.ps1
+++ b/Private/Show-Results.ps1
@@ -1,0 +1,22 @@
+function Show-Results {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [array]$Results
+    )
+
+    $IssueTable = @{
+        Credentials                 = 'Plaintext credentials'
+        AdminLogonScript            = 'Admins with logonscripts'
+        UnsafeUNCFilePermission     = 'Unsafe UNC file permissions'
+        UnsafeUNCFolderPermission   = 'Unsafe UNC folder permissions'
+        UnsafeLogonScriptPermission = 'Unsafe logon script permissions'
+    }
+
+    if ($null -ne $Results) {
+        $UniqueResults = $Results.Type | Sort-Object -Unique
+        Write-Host "########## $($IssueTable[$UniqueResults]) ##########"
+        # $Results | Format-List
+        $Results | Format-Table -Wrap
+    }
+}

--- a/Public/Invoke-ScriptSentry.ps1
+++ b/Public/Invoke-ScriptSentry.ps1
@@ -27,11 +27,17 @@ function Invoke-ScriptSentry {
     # Get a list of all logon scripts
     $LogonScripts = Get-LogonScripts
     
-    # Find logon scripts that contain unc paths (e.g. \\srv01\fileshare1)
+    # Find logon scripts (.bat, .vbs, .cmd, .ps1) that contain unc paths (e.g. \\srv01\fileshare1)
     $UNCScripts = Find-UNCScripts -LogonScripts $LogonScripts
 
-    # Find unsafe permissions for unc paths found in logon scripts
+    # Find mapped drives (e.g. \\srv01\fileshare1, \\srv02\fileshare2\accounting)
+    $MappedDrives = Find-MappedDrives -LogonScripts $LogonScripts
+
+    # Find unsafe permissions for unc files found in logon scripts
     Find-UnsafeUNCPermissions -UNCScripts $UNCScripts
+
+    # Find unsafe permissions for unc paths found in logon scripts
+    Find-UnsafeUNCPermissions -UNCScripts $MappedDrives
 
     # Find unsafe permissions on logon scripts
     Find-UnsafeLogonScriptPermissions -LogonScripts $LogonScripts

--- a/Public/Invoke-ScriptSentry.ps1
+++ b/Public/Invoke-ScriptSentry.ps1
@@ -22,7 +22,7 @@ function Invoke-ScriptSentry {
     [CmdletBinding()]
     Param()
 
-    Get-Art -Version '0.1'
+    Get-Art -Version '0.2_dev'
 
     # Get a list of all logon scripts
     $LogonScripts = Get-LogonScripts

--- a/Public/Invoke-ScriptSentry.ps1
+++ b/Public/Invoke-ScriptSentry.ps1
@@ -22,7 +22,7 @@ function Invoke-ScriptSentry {
     [CmdletBinding()]
     Param()
 
-    Get-Art -Version '0.2_dev'
+    Get-Art -Version '0.2'
 
     # Get a list of all logon scripts
     $LogonScripts = Get-LogonScripts
@@ -34,18 +34,24 @@ function Invoke-ScriptSentry {
     $MappedDrives = Find-MappedDrives -LogonScripts $LogonScripts
 
     # Find unsafe permissions for unc files found in logon scripts
-    Find-UnsafeUNCPermissions -UNCScripts $UNCScripts
+    $UnsafeUNCPermissions = Find-UnsafeUNCPermissions -UNCScripts $UNCScripts
 
     # Find unsafe permissions for unc paths found in logon scripts
-    Find-UnsafeUNCPermissions -UNCScripts $MappedDrives
+    $UnsafeMappedDrives = Find-UnsafeUNCPermissions -UNCScripts $MappedDrives
 
     # Find unsafe permissions on logon scripts
-    Find-UnsafeLogonScriptPermissions -LogonScripts $LogonScripts
+    $UnsafeLogonScripts = Find-UnsafeLogonScriptPermissions -LogonScripts $LogonScripts
 
     # Find admins that have logon scripts assigned
-    Find-AdminLogonScripts
+    $AdminLogonScripts = Find-AdminLogonScripts
 
     # Find credentials in logon scripts
-    Find-LogonScriptCredentials -LogonScripts $LogonScripts
+    $Credentials = Find-LogonScriptCredentials -LogonScripts $LogonScripts
 
+    # Show all results
+    Show-Results $UnsafeMappedDrives
+    Show-Results $UnsafeLogonScripts
+    Show-Results $UnsafeUNCPermissions
+    Show-Results $AdminLogonScripts
+    Show-Results $Credentials
 }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 ScriptSentry finds misconfigured and dangerous logon scripts.
 
 ### Additional Planned Features
+- [ ] Write a blog post about this tool/why I made it
+- [ ] Create an official release
+- [ ] Publish to PSGallery
 - [ ] Multi domain/forest support
 - [ ] Make output an object
 - [ ] Additional regex to search for other dangerous stuff in logon scripts

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ScriptSentry finds misconfigured and dangerous logon scripts.
 ### Additional Planned Features
 | status | Feature | Notes |
 | ------ | ------ | ------ |
-| In progress | make output an object | pushed to dev, needs testing
+| Done | make output an object | pushed to dev, needs testing
 | In progress | Additional regex to search for other dangerous stuff in logon scripts | Added detection for unsafe unc folder permissions |
 | ToDo | Write a blog post about this tool/why I made it | |
 | ToDo | Create an official release | |

--- a/README.md
+++ b/README.md
@@ -46,21 +46,52 @@ Invoke-ScriptSentry
 /\____) || (____/\| ) \ \_____) (___| )         | |   /\____) || (____/\| )  \  |   | |   | ) \ \__   | |
 \_______)(_______/|/   \__/\_______/|/          )_(   \_______)(_______/|/    )_)   )_(   |/   \__/   \_/
                               by: Spencer Alessi @techspence
-                                          v0.1                                
-[!] UNSAFE ACL FOUND!
-- File: \\eureka.local\sysvol\eureka.local\scripts\run.vbs
-- User: BUILTIN\Server Operators
-- Rights: ReadAndExecute, Synchronize
+                                          v0.2
 
-[!] Admins found with logon scripts
-- User: LDAP://CN=Administrator,CN=Users,DC=eureka,DC=local
-- logonscript: run.vbs
 
-- User: LDAP://CN=it admin,OU=Admins,OU=Eureka,DC=eureka,DC=local
-- logonscript: test.cmd
+########## Unsafe UNC folder permissions ##########
 
-[!] CREDENTIALS FOUND!
-- File: \\eureka.local\sysvol\eureka.local\scripts\test.cmd
-        - Credential: net use g: \\eureka-dc01\fileshare1 /user:user1 Password3355!
-        - Credential: net use h: \\eureka-dc01\fileshare1\accounting /user:userfoo Password5!
+Type                      File                                User          Rights
+----                      ----                                ----          ------
+UnsafeUNCFolderPermission \\eureka-dc01\fileshare1            Everyone FullControl
+UnsafeUNCFolderPermission \\eureka-dc01\fileshare1\accounting Everyone FullControl
+UnsafeUNCFolderPermission \\eureka-dc01\fileshare1\IT         Everyone FullControl
+
+
+########## Unsafe logon script permissions ##########
+
+Type                        File                                                   User                                                  Rights
+----                        ----                                                   ----                                                  ------
+UnsafeLogonScriptPermission \\eureka.local\sysvol\eureka.local\scripts\elevate.vbs NT AUTHORITY\Authenticated Users ReadAndExecute, Synchronize
+UnsafeLogonScriptPermission \\eureka.local\sysvol\eureka.local\scripts\elevate.vbs BUILTIN\Server Operators         ReadAndExecute, Synchronize
+UnsafeLogonScriptPermission \\eureka.local\sysvol\eureka.local\scripts\run.vbs     NT AUTHORITY\Authenticated Users ReadAndExecute, Synchronize
+UnsafeLogonScriptPermission \\eureka.local\sysvol\eureka.local\scripts\run.vbs     BUILTIN\Server Operators         ReadAndExecute, Synchronize
+UnsafeLogonScriptPermission \\eureka.local\sysvol\eureka.local\scripts\test.cmd    EUREKA\Domain Users                      Modify, Synchronize
+
+
+########## Unsafe UNC file permissions ##########
+
+Type                    File                                              User                                        Rights
+----                    ----                                              ----                                        ------
+UnsafeUNCFilePermission \\eureka-dc01\fileshare1\IT\securit360pentest.bat Everyone                               FullControl
+UnsafeUNCFilePermission \\eureka-dc01\fileshare1\run.bat                  EUREKA\testuser Write, ReadAndExecute, Synchronize
+UnsafeUNCFilePermission \\eureka-dc01\fileshare1\run.bat                  Everyone                               FullControl
+
+
+########## Admins with logonscripts ##########
+
+Type             User                                                      LogonScript
+----             ----                                                      -----------
+AdminLogonScript LDAP://CN=Administrator,CN=Users,DC=eureka,DC=local       run.vbs
+AdminLogonScript LDAP://CN=it admin,OU=Admins,OU=Eureka,DC=eureka,DC=local elevate.vbs
+
+
+########## Plaintext credentials ##########
+
+Type        File                                                   Credential
+----        ----                                                   ----------
+Credentials \\eureka.local\sysvol\eureka.local\scripts\ADCheck.ps1 $password = ConvertTo-SecureString -String "Password2468!" -AsPlainText -Force
+Credentials \\eureka.local\sysvol\eureka.local\scripts\shares.cmd  net use f: \\eureka-dc01\fileshare1\it /user:itadmin Password2468!
+Credentials \\eureka.local\sysvol\eureka.local\scripts\test.cmd    net use g: \\eureka-dc01\fileshare1 /user:user1 Password3355!
+Credentials \\eureka.local\sysvol\eureka.local\scripts\test.cmd    net use h: \\eureka-dc01\fileshare1\accounting /user:userfoo Password5!
 ```

--- a/ScriptSentry.ps1
+++ b/ScriptSentry.ps1
@@ -224,7 +224,7 @@ function Get-LogonScripts {
     $LogonScripts
 }
 
-Get-Art -Version '0.1'
+Get-Art -Version '0.2_dev'
 
 # Get a list of all logon scripts
 $LogonScripts = Get-LogonScripts

--- a/ScriptSentry.ps1
+++ b/ScriptSentry.ps1
@@ -105,7 +105,7 @@ function Find-LogonScriptCredentials {
     )
     foreach ($script in $LogonScripts) {
         # Write-Verbose -Message "Checking $($Script.FullName) for credentials.."
-        $Credentials = Get-Content -Path $script.FullName | Select-String -Pattern "/user:" -AllMatches
+        $Credentials = Get-Content -Path $script.FullName | Select-String -Pattern "/user:","-AsPlainText" -AllMatches
         if ($Credentials) {
             # "`n[!] CREDENTIALS FOUND!"
             $Credentials | ForEach-Object {

--- a/ScriptSentry.psd1
+++ b/ScriptSentry.psd1
@@ -7,7 +7,7 @@
     Description          = 'ScriptSentry finds misconfigured and dangerous logon scripts.'
     FunctionsToExport    = @('*')
     GUID                 = 'e1cd2b55-3b4f-41bd-a168-40db41e34349'
-    ModuleVersion        = '0.2_dev'
+    ModuleVersion        = '0.2'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/ScriptSentry.psd1
+++ b/ScriptSentry.psd1
@@ -7,7 +7,7 @@
     Description          = 'ScriptSentry finds misconfigured and dangerous logon scripts.'
     FunctionsToExport    = @('*')
     GUID                 = 'e1cd2b55-3b4f-41bd-a168-40db41e34349'
-    ModuleVersion        = '0.1'
+    ModuleVersion        = '0.2_dev'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/ScriptSentry.psm1
+++ b/ScriptSentry.psm1
@@ -1,4 +1,4 @@
-﻿# Get public and private function definition files.
+﻿# Get public and private function definition files. 
 $Public = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue -Recurse )
 $Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue -Recurse )
 $Classes = @( Get-ChildItem -Path $PSScriptRoot\Classes\*.ps1 -ErrorAction SilentlyContinue -Recurse )


### PR DESCRIPTION
Version 0.2 brings the following changes:

- ScriptSentry output is now an object (Thanks for the recommendation @PrzemyslawKlys)
- Added additional regex search for "-AsPlainText" to find plaintext credentials in PowerShell scripts (Thanks @rebelinux for the pr!)
- Added detection for unsafe UNC folder permissions (@techspence)