### PR TITLE
Update Invoke-ScriptSentry.ps1

### DIFF
--- a/Invoke-ScriptSentry.ps1
+++ b/Invoke-ScriptSentry.ps1
@@ -1562,7 +1562,9 @@ $ExploitableLogonScripts = $NonExistentSharesScripts | Where-Object {$_.Exploita
 $UnsafeUNCPermissions = Find-UnsafeUNCPermissions -UNCScripts $UNCScripts -SafeUsersList $SafeUsers
 
 # Find unsafe permissions for unc paths found in logon scripts
-$UnsafeMappedDrives = Find-UnsafeUNCPermissions -UNCScripts $MappedDrives -SafeUsersList $SafeUsers
+if ($null -ne $MappedDrives) {
+    $UnsafeMappedDrives = Find-UnsafeUNCPermissions -UNCScripts $MappedDrives -SafeUsersList $SafeUsers
+}
 
 # Find unsafe NETLOGON & SYSVOL share permissions
 $NetlogonSysvol = Get-NetlogonSysvol
@@ -1572,7 +1574,9 @@ $UnsafeNetlogonSysvol = Find-UnsafeUNCPermissions -UNCScripts $NetlogonSysvol -S
 $UnsafeLogonScripts = Find-UnsafeLogonScriptPermissions -LogonScripts $LogonScripts -SafeUsersList $SafeUsers
 
 # Find unsafe permissions on GPO logon scripts
-$UnsafeGPOLogonScripts = Find-UnsafeGPOLogonScriptPermissions -GPOLogonScripts $GPOLogonScripts -SafeUsersList $SafeUsers
+if ($null -ne $GPOLogonScripts) {
+    $UnsafeGPOLogonScripts = Find-UnsafeGPOLogonScriptPermissions -GPOLogonScripts $GPOLogonScripts -SafeUsersList $SafeUsers
+}
 
 # Find admins that have logon scripts assigned
 $AdminLogonScripts = Find-AdminLogonScripts -AdminUsers $AdminUsers


### PR DESCRIPTION
When running the tool on a domain without Mapped Drives nor GPO Logon Scripts, PowerShell hangs and then throws the exception `ParameterArgumentValidationErrorNullNotAllowed`. 

I wrapped the function calls that use `$GPOLogonScripts` and `$MappedDrives` with an if statement to check for null. This might be applicable for other variables.