### PR TITLE
Fix $null check position

### DIFF
--- a/Invoke-ScriptSentry.ps1
+++ b/Invoke-ScriptSentry.ps1
@@ -1204,7 +1204,7 @@ function Find-AdminLogonScripts {
     ) 
     # Enabled user accounts
     Foreach ($Admin in $AdminUsers) {
-        $AdminLogonScripts = Get-DomainUser -Identity $Admin.MemberName | Where-Object { $_.scriptPath -ne $null}
+        $AdminLogonScripts = Get-DomainUser -Identity $Admin.MemberName | Where-Object { $null -ne $_.scriptPath }
         
         # "`n[!] Admins found with logon scripts"
         $AdminLogonScripts | Foreach-object {


### PR DESCRIPTION
Minor fix for PSSA: $null should be on the left side of equality comparisons.