### PR TITLE
Merge dev updates and refresh ScriptSentry

### DIFF
--- a/Invoke-ScriptSentry.ps1
+++ b/Invoke-ScriptSentry.ps1
@@ -21,7 +21,11 @@ Invoke-ScriptSentry -SaveOutput $true
 #>
 [CmdletBinding()]
 Param(
-    [boolean]$SaveOutput = $false
+    [boolean]$SaveOutput = $false,
+    
+    [Management.Automation.PSCredential]
+    [Management.Automation.CredentialAttribute()]
+    $Credential = [Management.Automation.PSCredential]::Empty
 )
     
 function Get-ForestDomains {
@@ -1004,7 +1008,11 @@ function Get-DomainObject {
 }
 function Get-LogonScripts {
     [CmdletBinding()]
-    param()
+    param(
+        [Management.Automation.PSCredential]
+        [Management.Automation.CredentialAttribute()]
+        $Credential = [Management.Automation.PSCredential]::Empty
+    )
 
     # Get the current domain name from the environment
     # $currentDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
@@ -1024,7 +1032,11 @@ function Get-LogonScripts {
 }
 function Get-GPOLogonScripts {
     [CmdletBinding()]
-    param()
+    param(
+        [Management.Automation.PSCredential]
+        [Management.Automation.CredentialAttribute()]
+        $Credential = [Management.Automation.PSCredential]::Empty
+    )
 
     # Get the current domain name from the environment
     # $currentDomain = [System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
@@ -1200,7 +1212,10 @@ A custom PSObject with LDAP hashtable properties translated.
 function Find-AdminLogonScripts {
     [CmdletBinding()]
     param (
-        [array]$AdminUsers
+        [array]$AdminUsers,
+        [Management.Automation.PSCredential]
+        [Management.Automation.CredentialAttribute()]
+        $Credential = [Management.Automation.PSCredential]::Empty
     ) 
     # Enabled user accounts
     Foreach ($Admin in $AdminUsers) {
@@ -1221,7 +1236,10 @@ function Find-LogonScriptCredentials {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [array]$LogonScripts
+        [array]$LogonScripts,
+        [Management.Automation.PSCredential]
+        [Management.Automation.CredentialAttribute()]
+        $Credential = [Management.Automation.PSCredential]::Empty
     )
     foreach ($script in $LogonScripts) {
         # Write-Verbose -Message "Checking $($Script.FullName) for credentials.."
@@ -1243,7 +1261,10 @@ function Find-UNCScripts {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [array]$LogonScripts
+        [array]$LogonScripts,
+        [Management.Automation.PSCredential]
+        [Management.Automation.CredentialAttribute()]
+        $Credential = [Management.Automation.PSCredential]::Empty
     )
 
     $ExcludedMatches = "copy|&|/command|%WINDIR%|-i|\*"
@@ -1269,7 +1290,10 @@ function Find-MappedDrives {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [array]$LogonScripts
+        [array]$LogonScripts,
+        [Management.Automation.PSCredential]
+        [Management.Automation.CredentialAttribute()]
+        $Credential = [Management.Automation.PSCredential]::Empty
     )
 
     $Shares = @()
@@ -1302,7 +1326,10 @@ function Find-NonexistentShares {
     [CmdletBinding()]
     param (
         [array]$LogonScripts,
-        [array]$AdminUsers
+        [array]$AdminUsers,
+        [Management.Automation.PSCredential]
+        [Management.Automation.CredentialAttribute()]
+        $Credential = [Management.Automation.PSCredential]::Empty
     )
     $LogonScriptShares = @()
     [Array] $LogonScriptShares = foreach ($script in $LogonScripts) {
@@ -1371,7 +1398,10 @@ function Find-UnsafeLogonScriptPermissions {
         [Parameter(Mandatory = $true)]
         [array]$LogonScripts,
         [Parameter(Mandatory = $true)]
-        [array]$SafeUsersList
+        [array]$SafeUsersList,
+        [Management.Automation.PSCredential]
+        [Management.Automation.CredentialAttribute()]
+        $Credential = [Management.Automation.PSCredential]::Empty
     )
 
     $UnsafeRights = 'FullControl|Modify|Write'
@@ -1401,7 +1431,10 @@ function Find-UnsafeUNCPermissions {
         [Parameter(Mandatory = $true)]
         [array]$UNCScripts,
         [Parameter(Mandatory = $true)]
-        [array]$SafeUsersList
+        [array]$SafeUsersList,
+        [Management.Automation.PSCredential]
+        [Management.Automation.CredentialAttribute()]
+        $Credential = [Management.Automation.PSCredential]::Empty
     )
 
     $UnsafeRights = 'FullControl|Modify|Write'
@@ -1452,7 +1485,10 @@ function Find-UnsafeLogonScriptPermissions {
         [Parameter(Mandatory = $true)]
         [array]$LogonScripts,
         [Parameter(Mandatory = $true)]
-        [array]$SafeUsersList
+        [array]$SafeUsersList,
+        [Management.Automation.PSCredential]
+        [Management.Automation.CredentialAttribute()]
+        $Credential = [Management.Automation.PSCredential]::Empty
     )
 
     $UnsafeRights = 'FullControl|Modify|Write'
@@ -1482,7 +1518,10 @@ function Find-UnsafeGPOLogonScriptPermissions {
         [Parameter(Mandatory = $true)]
         [array]$GPOLogonScripts,
         [Parameter(Mandatory = $true)]
-        [array]$SafeUsersList
+        [array]$SafeUsersList,
+        [Management.Automation.PSCredential]
+        [Management.Automation.CredentialAttribute()]
+        $Credential = [Management.Automation.PSCredential]::Empty
     )
 
     $UnsafeRights = 'FullControl|Modify|Write'
@@ -1538,33 +1577,127 @@ Get-Art -Version '0.6'
 
 $SafeUsers = 'NT AUTHORITY\\SYSTEM|Administrator|NT SERVICE\\TrustedInstaller|Domain Admins|Server Operators|Enterprise Admins|CREATOR OWNER'
 $AdminGroups = @("Account Operators", "Administrators", "Backup Operators", "Cryptographic Operators", "Distributed COM Users", "Domain Admins", "Domain Controllers", "Enterprise Admins", "Print Operators", "Schema Admins", "Server Operators")
-$AdminUsers = $AdminGroups | ForEach-Object { (Get-DomainGroupMember -Identity $_ -Recurse | Where-Object {$_.MemberObjectClass -eq 'user'})} | Sort-Object -Property MemberName -Unique
-$AdminUsers | ForEach-Object { $SafeUsers = $SafeUsers + '|' + $_.MemberName }
 
-# Get a list of all logon scripts
-$LogonScripts = Get-LogonScripts
-
-# Get a list of all GPO logon scripts
-$GPOLogonScripts = Get-GPOLogonScripts
-
-if ($LogonScripts) {
-    # Find logon scripts (.bat, .vbs, .cmd, .ps1, .kix) that contain unc paths (e.g. \\srv01\fileshare1)
-    $UNCScripts = Find-UNCScripts -LogonScripts $LogonScripts
-
-    # Find mapped drives (e.g. \\srv01\fileshare1, \\srv02\fileshare2\accounting)
-    $MappedDrives = Find-MappedDrives -LogonScripts $LogonScripts
-
-    # Find nonexistent shares
-    $NonExistentSharesScripts = Find-NonexistentShares -LogonScripts $LogonScripts -AdminUsers $AdminUsers
-    $NonExistentShares = $NonExistentSharesScripts | Where-Object {$_.Exploitable -eq 'Potentially'} | Sort-Object -Property Share -Unique
-
-    # Find unsafe permissions on logon scripts
-    $UnsafeLogonScripts = Find-UnsafeLogonScriptPermissions -LogonScripts $LogonScripts -SafeUsersList $SafeUsers
-
-    # Find credentials in logon scripts
-    $Credentials = Find-LogonScriptCredentials -LogonScripts $LogonScripts
+if ($Credential.UserName) {
+        Write-Host "[i] Credentials detected. Running ScriptSentry as: $($Credential.UserName)"
 } else {
-    Write-Host "[i] No logon scripts found!`n" -ForegroundColor Cyan
+    # nothing, no creds supplied
+}
+
+if ($Credential.UserName) {
+    $AdminUsers = $AdminGroups | ForEach-Object { (Get-DomainGroupMember -Identity $_ -Recurse -Credential $Credential | Where-Object {$_.MemberObjectClass -eq 'user'})} | Sort-Object -Property MemberName -Unique
+    $AdminUsers | ForEach-Object { $SafeUsers = $SafeUsers + '|' + $_.MemberName }
+
+    # Get a list of all logon scripts
+    $LogonScripts = Get-LogonScripts -Credential $Credential
+
+    # Get a list of all GPO logon scripts
+    $GPOLogonScripts = Get-GPOLogonScripts -Credential $Credential
+
+    if ($LogonScripts) {
+        # Find logon scripts (.bat, .vbs, .cmd, .ps1, .kix) that contain unc paths (e.g. \\srv01\fileshare1)
+        $UNCScripts = Find-UNCScripts -LogonScripts $LogonScripts -Credential $Credential
+
+        # Find mapped drives (e.g. \\srv01\fileshare1, \\srv02\fileshare2\accounting)
+        $MappedDrives = Find-MappedDrives -LogonScripts $LogonScripts -Credential $Credential
+
+        # Find nonexistent shares
+        $NonExistentSharesScripts = Find-NonexistentShares -LogonScripts $LogonScripts -AdminUsers $AdminUsers -Credential $Credential
+        $NonExistentShares = $NonExistentSharesScripts | Where-Object {$_.Exploitable -eq 'Potentially'} | Sort-Object -Property Share -Unique
+
+        # Find unsafe permissions on logon scripts
+        $UnsafeLogonScripts = Find-UnsafeLogonScriptPermissions -LogonScripts $LogonScripts -SafeUsersList $SafeUsers -Credential $Credential
+
+        # Find credentials in logon scripts
+        $Credentials = Find-LogonScriptCredentials -LogonScripts $LogonScripts -Credential $Credential
+    } else {
+        Write-Host "[i] No logon scripts found!`n" -ForegroundColor Cyan
+    }
+    
+    if ($UNCScripts) {
+        # Find unsafe permissions for unc files found in logon scripts
+        $UnsafeUNCPermissions = Find-UnsafeUNCPermissions -UNCScripts $UNCScripts -SafeUsersList $SafeUsers -Credential $Credential
+    } else {
+        Write-Host "[i] No UNC files found!`n" -ForegroundColor Cyan
+    }
+    
+    if ($MappedDrives) {
+        # Find unsafe permissions for unc paths found in logon scripts
+        $UnsafeMappedDrives = Find-UnsafeUNCPermissions -UNCScripts $MappedDrives -SafeUsersList $SafeUsers -Credential $Credential
+    } else {
+        Write-Host "[i] No mapped drives found!`n" -ForegroundColor Cyan
+    }
+
+    # Find unsafe NETLOGON & SYSVOL share permissions
+    $NetlogonSysvol = Get-NetlogonSysvol
+    $UnsafeNetlogonSysvol = Find-UnsafeUNCPermissions -UNCScripts $NetlogonSysvol -SafeUsersList $SafeUsers -Credential $Credential
+
+    if ($GPOLogonScripts) {
+        # Find unsafe permissions on GPO logon scripts
+        $UnsafeGPOLogonScripts = Find-UnsafeGPOLogonScriptPermissions -GPOLogonScripts $GPOLogonScripts -SafeUsersList $SafeUsers -Credential $Credential
+    } else {
+        Write-Host "[i] No GPO logon scripts found!`n" -ForegroundColor Cyan
+    }
+
+    # Find admins that have logon scripts assigned
+    $AdminLogonScripts = Find-AdminLogonScripts -AdminUsers $AdminUsers -Credential $Credential
+} else {
+    $AdminUsers = $AdminGroups | ForEach-Object { (Get-DomainGroupMember -Domain (Get-Domain).Name -Identity $_ -Recurse | Where-Object {$_.MemberObjectClass -eq 'user'})} | Sort-Object -Property MemberName -Unique
+    $AdminUsers | ForEach-Object { $SafeUsers = $SafeUsers + '|' + $_.MemberName }
+
+    # Get a list of all logon scripts
+    $LogonScripts = Get-LogonScripts
+
+    # Get a list of all GPO logon scripts
+    $GPOLogonScripts = Get-GPOLogonScripts
+
+    if ($LogonScripts) {
+        # Find logon scripts (.bat, .vbs, .cmd, .ps1, .kix) that contain unc paths (e.g. \\srv01\fileshare1)
+        $UNCScripts = Find-UNCScripts -LogonScripts $LogonScripts
+
+        # Find mapped drives (e.g. \\srv01\fileshare1, \\srv02\fileshare2\accounting)
+        $MappedDrives = Find-MappedDrives -LogonScripts $LogonScripts
+
+        # Find nonexistent shares
+        $NonExistentSharesScripts = Find-NonexistentShares -LogonScripts $LogonScripts -AdminUsers $AdminUsers
+        $NonExistentShares = $NonExistentSharesScripts | Where-Object {$_.Exploitable -eq 'Potentially'} | Sort-Object -Property Share -Unique
+
+        # Find unsafe permissions on logon scripts
+        $UnsafeLogonScripts = Find-UnsafeLogonScriptPermissions -LogonScripts $LogonScripts -SafeUsersList $SafeUsers
+
+        # Find credentials in logon scripts
+        $Credentials = Find-LogonScriptCredentials -LogonScripts $LogonScripts
+    } else {
+        Write-Host "[i] No logon scripts found!`n" -ForegroundColor Cyan
+    }
+
+    if ($UNCScripts) {
+        # Find unsafe permissions for unc files found in logon scripts
+        $UnsafeUNCPermissions = Find-UnsafeUNCPermissions -UNCScripts $UNCScripts -SafeUsersList $SafeUsers
+    } else {
+        Write-Host "[i] No UNC files found!`n" -ForegroundColor Cyan
+    }
+    
+    if ($MappedDrives) {
+        # Find unsafe permissions for unc paths found in logon scripts
+        $UnsafeMappedDrives = Find-UnsafeUNCPermissions -UNCScripts $MappedDrives -SafeUsersList $SafeUsers
+    } else {
+        Write-Host "[i] No mapped drives found!`n" -ForegroundColor Cyan
+    }
+
+    # Find unsafe NETLOGON & SYSVOL share permissions
+    $NetlogonSysvol = Get-NetlogonSysvol
+    $UnsafeNetlogonSysvol = Find-UnsafeUNCPermissions -UNCScripts $NetlogonSysvol -SafeUsersList $SafeUsers
+
+    if ($GPOLogonScripts) {
+        # Find unsafe permissions on GPO logon scripts
+        $UnsafeGPOLogonScripts = Find-UnsafeGPOLogonScriptPermissions -GPOLogonScripts $GPOLogonScripts -SafeUsersList $SafeUsers
+    } else {
+        Write-Host "[i] No GPO logon scripts found!`n" -ForegroundColor Cyan
+    }
+
+    # Find admins that have logon scripts assigned
+    $AdminLogonScripts = Find-AdminLogonScripts -AdminUsers $AdminUsers
 }
 
 if ($NonExistentShares) {
@@ -1573,34 +1706,6 @@ if ($NonExistentShares) {
 } else {
     Write-Host "[i] No non-existent shares found!`n" -ForegroundColor Cyan
 }
-
-if ($UNCScripts) {
-    # Find unsafe permissions for unc files found in logon scripts
-    $UnsafeUNCPermissions = Find-UnsafeUNCPermissions -UNCScripts $UNCScripts -SafeUsersList $SafeUsers
-} else {
-    Write-Host "[i] No UNC files found!`n" -ForegroundColor Cyan
-}
-
-if ($MappedDrives) {
-    # Find unsafe permissions for unc paths found in logon scripts
-    $UnsafeMappedDrives = Find-UnsafeUNCPermissions -UNCScripts $MappedDrives -SafeUsersList $SafeUsers
-} else {
-    Write-Host "[i] No mapped drives found!`n" -ForegroundColor Cyan
-}
-
-# Find unsafe NETLOGON & SYSVOL share permissions
-$NetlogonSysvol = Get-NetlogonSysvol
-$UnsafeNetlogonSysvol = Find-UnsafeUNCPermissions -UNCScripts $NetlogonSysvol -SafeUsersList $SafeUsers
-
-if ($GPOLogonScripts) {
-    # Find unsafe permissions on GPO logon scripts
-    $UnsafeGPOLogonScripts = Find-UnsafeGPOLogonScriptPermissions -GPOLogonScripts $GPOLogonScripts -SafeUsersList $SafeUsers
-} else {
-    Write-Host "[i] No GPO logon scripts found!`n" -ForegroundColor Cyan
-}
-
-# Find admins that have logon scripts assigned
-$AdminLogonScripts = Find-AdminLogonScripts -AdminUsers $AdminUsers
 
 # Show all results
 if ($UnsafeMappedDrives) {Show-Results $UnsafeMappedDrives}

--- a/Invoke-ScriptSentry.ps1
+++ b/Invoke-ScriptSentry.ps1
@@ -1225,7 +1225,7 @@ function Find-LogonScriptCredentials {
     )
     foreach ($script in $LogonScripts) {
         # Write-Verbose -Message "Checking $($Script.FullName) for credentials.."
-        $Credentials = Get-Content -Path $script.FullName -ErrorAction SilentlyContinue | Select-String -Pattern "/user:","-AsPlainText" -AllMatches
+        $Credentials = Get-Content -Path $script.FullName -ErrorAction SilentlyContinue | Select-String -Pattern "/u[\w]*:","-AsPlainText" -AllMatches
         if ($Credentials) {
             # "`n[!] CREDENTIALS FOUND!"
             $Credentials | ForEach-Object {

--- a/Invoke-ScriptSentry.ps1
+++ b/Invoke-ScriptSentry.ps1
@@ -1204,7 +1204,7 @@ function Find-AdminLogonScripts {
     ) 
     # Enabled user accounts
     Foreach ($Admin in $AdminUsers) {
-        $AdminLogonScripts = Get-DomainUser -Identity $Admin.MemberName | Where-Object { $_.scriptPath -ne $null}
+        $AdminLogonScripts = Get-DomainUser -Identity $Admin.MemberName | Where-Object { $null -ne $_.scriptPath }
         
         # "`n[!] Admins found with logon scripts"
         $AdminLogonScripts | Foreach-object {


### PR DESCRIPTION
## Summary

- merge the existing dev work with the current main branch
- add LDAP credentials and explicit domain controller targeting
- keep the refactored findings and consolidated CSV output
- fix SYSVOL discovery, mapped path extraction, and false negatives found during DC01 testing
- update usage documentation and example output

## Validation

- PowerShell parsing passed
- default discovery tested on DC01
- `-Server DC01.dunder.corp -Domain dunder.corp` tested on DC01
- staged unsafe ACLs, plaintext credentials, UNC paths, GPO scripts, and nonexistent shares were detected

`-Credential` applies to LDAP queries. UNC and SMB access continues to use the PowerShell process identity.

Closes #20
Addresses #23